### PR TITLE
Fix package naming and manifest package

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.example.myapplication">
 
     <uses-permission android:name="android.permission.CAMERA" />
 

--- a/app/src/main/java/com/example/myapplication/CameraActivity.kt
+++ b/app/src/main/java/com/example/myapplication/CameraActivity.kt
@@ -1,4 +1,4 @@
-package com.example.yourappname
+package com.example.myapplication
 
 import android.content.Intent
 import android.os.Bundle

--- a/app/src/main/java/com/example/myapplication/MainActivity.kt
+++ b/app/src/main/java/com/example/myapplication/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.yourappname
+package com.example.myapplication
 
 import android.Manifest
 import android.content.Intent
@@ -11,7 +11,7 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 
 // Activity that shows camera preview and takes a photo
-import com.example.yourappname.CameraActivity
+import com.example.myapplication.CameraActivity
 
 class MainActivity : AppCompatActivity() {
 


### PR DESCRIPTION
## Summary
- fix incorrect package name in `CameraActivity` and `MainActivity`
- add explicit package attribute to `AndroidManifest.xml`

## Testing
- `./gradlew --version` *(fails: Unable to download Gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_688357f4a02c832bb6cf63b721d70fbe